### PR TITLE
Add generic_syscall, and implement random entropy, to allow Bash to launch.

### DIFF
--- a/monika/linux/CMakeLists.txt
+++ b/monika/linux/CMakeLists.txt
@@ -36,7 +36,8 @@ set(monika_sources
     threading.cpp
     time.cpp
     timer.cpp
-    userid.cpp)
+    userid.cpp
+    generic_syscall.cpp)
 
 add_library(monika_static STATIC ${monika_sources})
 


### PR DESCRIPTION
This adds the generic_syscall syscall, and implements the random entropy system so that bash will launch. This also includes the correct types for the syscall implementation.