### PR TITLE
Fix compiling with latest GCC

### DIFF
--- a/haiku_loader/loader_lock.h
+++ b/haiku_loader/loader_lock.h
@@ -1,5 +1,5 @@
 #ifndef __LOADER_LOCK_H__
-#define __LODAER_LOCK_H__
+#define __LOADER_LOCK_H__
 
 void loader_lock_subsystem(int* subsystemId);
 void loader_unlock_subsystem(int subsystemId);

--- a/hyclone_server/server_systemnotification.h
+++ b/hyclone_server/server_systemnotification.h
@@ -1,6 +1,7 @@
 #ifndef __SERVER_SYSTEMNOTIFICATION_H__
 #define __SERVER_SYSTEMNOTIFICATION_H__
 
+#include <algorithm>
 #include <list>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Fixes a typo in the include guard for haiku_loader/loader_lock.h and a missing import for std algorithm in hyclone_server/server_systemnotification.h

Edit: The errors this fixes seem to only happen on the newer GCC versions. I am using GCC 15.1.1 20250729, but tested on 12.2.0 and it does not happen there.